### PR TITLE
Add German Translations for Mailchimp Plugin

### DIFF
--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -1,0 +1,9 @@
+bitbag_sylius_mailchimp_plugin:
+    ui:
+        newsletter: 'Newsletter'
+        subscribe: 'Abonnieren'
+        your_email_address: 'Ihre E-Mail-Adresse'
+        subscribed_successfully: 'Sie sind jetzt für den Newsletter angemeldet.'
+        invalid_csrf_token: 'Das eingereichte CSRF-Token ist ungültig.'
+        unsubscribed_successfully: 'Sie sind jetzt vom Newsletter abgemeldet.'
+        invalid_variable_type: 'Ungültiger Variablentyp'

--- a/src/Resources/translations/validators.de.yml
+++ b/src/Resources/translations/validators.de.yml
@@ -1,0 +1,9 @@
+bitbag_sylius_mailchimp_plugin:
+    ui:
+        invalid_email: 'Die eingegebene E-Mail-Adresse ist nicht gültig.'
+        email_not_blank: 'Bitte füllen Sie das E-Mail-Feld aus.'
+        unique_email: 'Die angegebene E-Mail-Adresse ist bereits für den Newsletter angemeldet.'
+        invalid_list_id_malichimp: 'Die angegebene Listen-ID unterscheidet sich von der konfigurierten.'
+        invalid_list_id_configured: 'Die angegebene Listen-ID stimmt nicht mit denjenigen in Ihrem Mailchimp-Konto überein.'
+        invalid_query_secret: 'Das vom Webhook gesendete Abfragegeheimnis unterscheidet sich von dem konfigurierten.'
+        invalid_webhook_type: 'Ungültiger Webhook-Typ angegeben.'


### PR DESCRIPTION
This pull request adds German translations for various messages in the BitBag Mailchimp Plugin. The translations aim to improve the user experience for German-speaking users by providing localized messages for input validations and user interactions.

Changes include:
- Added translations for validation messages related to email subscriptions and errors.

This update ensures consistency with existing localization efforts and enhances the overall usability of the plugin for German-speaking customers.
